### PR TITLE
Feat: Responsive design

### DIFF
--- a/src/components/common/Button.svelte
+++ b/src/components/common/Button.svelte
@@ -49,7 +49,7 @@
 </script>
 
 <button
-  class="flex flex-row items-center px-3 py-2 gap-2 h-10 {backgound} border rounded-md {border} font-default {text} {className}"
+  class="flex flex-row items-center justify-center px-3 py-2 gap-2 h-10 {backgound} border rounded-md {border} font-default {text} {className}"
   on:click
 >
   {#if iconName}

--- a/src/components/page/data_mapping/DataOperationsBar/CreateDataForm.svelte
+++ b/src/components/page/data_mapping/DataOperationsBar/CreateDataForm.svelte
@@ -84,7 +84,7 @@
 </script>
 
 <div
-  class="border-b border-app-drawer-border h-16 flex flex-row items-center px-6 justify-between"
+  class="border-b border-app-drawer-border h-16 flex flex-row items-center px-6 justify-between mobile:max-md:px-4"
 >
   <p class="text-base font-semibold text-app-black">New Data</p>
   <div class="flex flex-row gap-x-3">
@@ -92,7 +92,7 @@
     <Button variant="primary" label="Save" on:click={onCreate} />
   </div>
 </div>
-<div class="py-4 px-6 flex flex-col gap-y-6">
+<div class="py-4 px-6 flex flex-col gap-y-6 mobile:max-md:px-4">
   {#if otherError}
     <div role="alert" class="alert alert-error">
       Failed to create data: {otherError}

--- a/src/components/page/data_mapping/DataOperationsBar/ExportButton.svelte
+++ b/src/components/page/data_mapping/DataOperationsBar/ExportButton.svelte
@@ -1,5 +1,11 @@
 <script lang="ts">
   import Button from "@common/Button.svelte";
+  import "styles/data_mapping_bar.css";
 </script>
 
-<Button variant="secondary" label="Export" iconName="mdi:tray-download" />
+<Button
+  variant="secondary"
+  label="Export"
+  iconName="mdi:tray-download"
+  className="icon-only-on-mobile"
+/>

--- a/src/components/page/data_mapping/DataOperationsBar/FilterButton.svelte
+++ b/src/components/page/data_mapping/DataOperationsBar/FilterButton.svelte
@@ -2,6 +2,7 @@
   import Button from "@common/Button.svelte";
   import { CONTEXT_KEY_DATA_MAPPING_REPOSITORY } from "constants/contextKeys";
   import type { IDataMappingRepository } from "repository/types";
+  import "styles/data_mapping_bar.css";
   import "styles/drawer.css";
   import { getContext } from "svelte";
   import FilterDataForm from "./FilterDataForm.svelte";
@@ -32,6 +33,7 @@
     <Button
       variant="secondary"
       iconName="mdi:filter-variant"
+      className="icon-only-on-mobile"
       on:click={openDialog}
       {label}
     />

--- a/src/components/page/data_mapping/DataOperationsBar/FilterButton.svelte
+++ b/src/components/page/data_mapping/DataOperationsBar/FilterButton.svelte
@@ -44,7 +44,7 @@
       aria-label="close sidebar"
       class="drawer-overlay"
     />
-    <div class="bg-white w-drawer-width h-full">
+    <div class="bg-white">
       <FilterDataForm on:CLOSE_FORM={closeDialog} />
     </div>
   </div>

--- a/src/components/page/data_mapping/DataOperationsBar/FilterDataForm.svelte
+++ b/src/components/page/data_mapping/DataOperationsBar/FilterDataForm.svelte
@@ -38,7 +38,7 @@
 </script>
 
 <div
-  class="border-b border-app-drawer-border h-16 flex flex-row items-center px-6 justify-between"
+  class="border-b border-app-drawer-border h-16 flex flex-row items-center px-6 justify-between mobile:max-md:px-4"
 >
   <div class="flex justify-start items-center gap-x-2">
     <Icon icon="mdi:filter-variant" class="text-base" />
@@ -49,7 +49,9 @@
     <Button variant="primary" label="Apply Filter" on:click={applyFilter} />
   </div>
 </div>
-<div class="flex flex-row px-4 py-3 gap-x-2 border-b border-app-drawer-border">
+<div
+  class="flex flex-row px-4 py-3 gap-x-2 border-b border-app-drawer-border mobile:max-md:px-4"
+>
   <Icon icon="mdi:magnify" class="text-2xl" />
   <input
     id="text-filter"
@@ -58,7 +60,7 @@
     bind:value={textSearch}
   />
 </div>
-<div class="flex flex-col gap-y-3 py-4 px-6">
+<div class="flex flex-col gap-y-3 py-4 px-6 mobile:max-md:px-4">
   <p class="font-default font-semibold text-xs leading-5 text-app-title-text">
     DEPARTMENT
   </p>
@@ -67,7 +69,7 @@
     bind:values={departments}
   />
 </div>
-<div class="flex flex-col gap-y-3 py-4 px-6">
+<div class="flex flex-col gap-y-3 py-4 px-6 mobile:max-md:px-4">
   <p class="font-default font-semibold text-xs leading-5 text-app-title-text">
     DATA SUBJECT
   </p>

--- a/src/components/page/data_mapping/DataOperationsBar/ImportButton.svelte
+++ b/src/components/page/data_mapping/DataOperationsBar/ImportButton.svelte
@@ -1,5 +1,11 @@
 <script lang="ts">
   import Button from "@common/Button.svelte";
+  import "styles/data_mapping_bar.css";
 </script>
 
-<Button variant="secondary" label="Import" iconName="mdi:tray-upload" />
+<Button
+  variant="secondary"
+  label="Import"
+  iconName="mdi:tray-upload"
+  className="icon-only-on-mobile"
+/>

--- a/src/components/page/data_mapping/DataOperationsBar/NewDataButton.svelte
+++ b/src/components/page/data_mapping/DataOperationsBar/NewDataButton.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import Button from "@common/Button.svelte";
+  import "styles/data_mapping_bar.css";
   import "styles/drawer.css";
   import CreateDataForm from "./CreateDataForm.svelte";
 
@@ -8,18 +9,19 @@
   const closeDialog = () => (checked = false);
 </script>
 
-<div class="drawer drawer-end">
+<div class="drawer drawer-end flex grow">
   <input
     id="create-data-drawer"
     type="checkbox"
     class="drawer-toggle"
     bind:checked
   />
-  <div class="drawer-content">
+  <div class="drawer-content w-full">
     <Button
       variant="primary"
       label="New Data"
       iconName="mdi:plus"
+      className="w-full"
       on:click={openDialog}
     />
   </div>

--- a/src/components/page/data_mapping/DataOperationsBar/NewDataButton.svelte
+++ b/src/components/page/data_mapping/DataOperationsBar/NewDataButton.svelte
@@ -31,7 +31,7 @@
       aria-label="close sidebar"
       class="drawer-overlay"
     />
-    <div class="bg-white w-drawer-width h-full">
+    <div class="bg-white">
       <CreateDataForm on:CLOSE_FORM={closeDialog} />
     </div>
   </div>

--- a/src/components/page/data_mapping/DataOperationsBar/index.svelte
+++ b/src/components/page/data_mapping/DataOperationsBar/index.svelte
@@ -5,11 +5,13 @@
   import NewDataButton from "./NewDataButton.svelte";
 </script>
 
-<div class="flex flex-row justify-between items-center">
-  <h1 class="text-2xl font-default font-semibold tracking-tight">
+<div
+  class="flex flex-row justify-between items-center mobile:max-md:flex-col mobile:max-md:items-start mobile:max-md:gap-y-3"
+>
+  <h1 class="text-2xl font-default font-semibold tracking-tight text-nowrap">
     Data Mapping
   </h1>
-  <div class="flex flex-row gap-3">
+  <div class="flex flex-row gap-x-3 mobile:max-md:w-full">
     <FilterButton />
     <ExportButton />
     <ImportButton />

--- a/src/components/page/data_mapping/Tabs/DataMappingTab.svelte
+++ b/src/components/page/data_mapping/Tabs/DataMappingTab.svelte
@@ -11,7 +11,7 @@
   );
 </script>
 
-<div class="flex flex-col gap-y-6 py-6">
+<div class="flex flex-col gap-y-6 pt-6">
   <div class="flex flex-row gap-3">
     <EditButton />
     <VisualizeButton />

--- a/src/components/page/data_mapping/Tabs/DataMappingTab.svelte
+++ b/src/components/page/data_mapping/Tabs/DataMappingTab.svelte
@@ -11,7 +11,9 @@
   );
 </script>
 
-<div class="flex flex-col gap-y-6 pt-6">
+<div
+  class="flex flex-col gap-y-6 pt-6 mobile:max-md:pt-4 mobile:max-md:gap-y-4"
+>
   <div class="flex flex-row gap-3">
     <EditButton />
     <VisualizeButton />

--- a/src/components/page/data_mapping/Tabs/Table.svelte
+++ b/src/components/page/data_mapping/Tabs/Table.svelte
@@ -28,6 +28,7 @@
                 </div>
               </th>
             {/each}
+            <th></th>
           </tr>
         </thead>
         <tbody>

--- a/src/components/page/data_mapping/Tabs/Table.svelte
+++ b/src/components/page/data_mapping/Tabs/Table.svelte
@@ -9,7 +9,9 @@
   export let data: ReadableAtom<WithMetadata<DataMappingPresentation[]>>;
 </script>
 
-<div class="p-6 bg-white border rounded-md border-app-border-default">
+<div
+  class="p-6 bg-white border rounded-md border-app-border-default mobile:max-md:p-4"
+>
   {#if $data.status === "loading"}
     <h1 class="text-2xl font-default">Loading...</h1>
   {:else if $data.status === "done"}
@@ -54,7 +56,7 @@
       </table>
     </div>
     <div
-      class="w-full flex flex-row justify-end h-20 items-end mobile:max-xl:h-12"
+      class="w-full flex flex-row justify-end h-20 items-end md:max-xl:h-12 mobile:max-md:h-10"
     >
       <p class="font-normal text-sm text-app-title-text">
         Showing 1-{$data.data.length} of {$data.data.length}

--- a/src/components/page/data_mapping/Tabs/Table.svelte
+++ b/src/components/page/data_mapping/Tabs/Table.svelte
@@ -13,7 +13,7 @@
   {#if $data.status === "loading"}
     <h1 class="text-2xl font-default">Loading...</h1>
   {:else if $data.status === "done"}
-    <div class="overflow-x-auto">
+    <div class="overflow-x-scroll">
       <table class="table">
         <thead>
           <tr class="font-default text-sm leading-6 text-app-title-text">
@@ -51,12 +51,14 @@
           {/each}
         </tbody>
       </table>
-      <div class="w-full flex flex-row justify-end h-20 items-end">
-        <p class="font-normal text-sm text-app-title-text">
-          Showing 1-{$data.data.length} of {$data.data.length}
-          results
-        </p>
-      </div>
+    </div>
+    <div
+      class="w-full flex flex-row justify-end h-20 items-end mobile:max-xl:h-12"
+    >
+      <p class="font-normal text-sm text-app-title-text">
+        Showing 1-{$data.data.length} of {$data.data.length}
+        results
+      </p>
     </div>
   {/if}
 </div>

--- a/src/components/page/data_mapping/Tabs/index.svelte
+++ b/src/components/page/data_mapping/Tabs/index.svelte
@@ -5,7 +5,7 @@
   import DataMappingTab from "./DataMappingTab.svelte";
 </script>
 
-<div role="tablist" class="tabs tabs-bordered">
+<div role="tablist" class="tabs tabs-bordered max-w-full overflow-x-hidden">
   <!-- svelte-ignore a11y-missing-attribute -->
   <a role="tab" class="tab tab-active">
     <DataMappingIcon />

--- a/src/layouts/Footer.astro
+++ b/src/layouts/Footer.astro
@@ -1,3 +1,3 @@
-<div class="absolute py-3 px-6 bottom-0 left-0 w-full">
+<div class="relative py-3 px-6 bottom-0 left-0 w-full bg-app-bg">
   <p class="leading-5 text-xs text-app-bg-text">© Criclabs</p>
 </div>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -25,7 +25,7 @@ const { pageId } = Astro.props;
   </head>
   <body>
     <Navbar />
-    <div class="static w-full main_section">
+    <div class="w-full main_section">
       <div class="flex flex-row mobile:max-xl:flex-col">
         <Menus pageId={pageId} />
         <div class="p-6 w-full">
@@ -33,7 +33,7 @@ const { pageId } = Astro.props;
           <slot />
         </div>
       </div>
-      <Footer />
     </div>
+    <Footer />
   </body>
 </html>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -26,7 +26,7 @@ const { pageId } = Astro.props;
   <body>
     <Navbar />
     <div class="static w-full main_section">
-      <div class="flex flex-row">
+      <div class="flex flex-row mobile:max-xl:flex-col">
         <Menus pageId={pageId} />
         <div class="p-6 w-full">
           <Path pageId={pageId} />

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -28,7 +28,7 @@ const { pageId } = Astro.props;
     <div class="w-full main_section">
       <div class="flex flex-row mobile:max-xl:flex-col">
         <Menus pageId={pageId} />
-        <div class="p-6 w-full">
+        <div class="p-6 w-full mobile:max-md:p-4">
           <Path pageId={pageId} />
           <slot />
         </div>

--- a/src/layouts/Menus.astro
+++ b/src/layouts/Menus.astro
@@ -10,7 +10,7 @@ const { pageId } = Astro.props;
 
 <div
   class="p-6 flex flex-col
-  mobile:max-xl:flex-row mobile:max-xl:gap-x-6 mobile:max-xl:h-14 mobile:max-xl:py-2 mobile:max-xl:px-6 mobile:max-xl:overflow-x-auto mobile:max-xl:border-b mobile:max-xl:border-app-border-default"
+  mobile:max-xl:flex-row mobile:max-xl:gap-x-6 mobile:max-xl:h-14 mobile:max-xl:py-2 mobile:max-xl:overflow-x-auto mobile:max-xl:border-b mobile:max-xl:border-app-border-default md:max-xl:px-6 mobile:max-md:px-4"
 >
   {
     MENUS.map(({ iconName, label, id }) => {

--- a/src/layouts/Menus.astro
+++ b/src/layouts/Menus.astro
@@ -19,7 +19,7 @@ const { pageId } = Astro.props;
       const labelColor = id === pageId ? "text-app-green" : "text-app-black";
 
       return (
-        <div class="flex flex-row w-[200px] py-2 gap-x-2 mobile:max-xl:min-w-fit">
+        <div class="flex flex-row xl:w-[200px] py-2 gap-x-2 mobile:max-xl:min-w-fit items-center">
           <Icon name={iconName} class={`text-2xl ${iconStrokeColor}`} />
           <p
             class={`font-default text-sm font-semibold leading-6 text-left ${labelColor}`}

--- a/src/layouts/Menus.astro
+++ b/src/layouts/Menus.astro
@@ -8,7 +8,10 @@ interface Props {
 const { pageId } = Astro.props;
 ---
 
-<div class="p-6">
+<div
+  class="p-6 flex flex-col
+  mobile:max-xl:flex-row mobile:max-xl:gap-x-6 mobile:max-xl:h-14 mobile:max-xl:py-2 mobile:max-xl:px-6 mobile:max-xl:overflow-x-auto mobile:max-xl:border-b mobile:max-xl:border-app-border-default"
+>
   {
     MENUS.map(({ iconName, label, id }) => {
       const iconStrokeColor =
@@ -16,10 +19,10 @@ const { pageId } = Astro.props;
       const labelColor = id === pageId ? "text-app-green" : "text-app-black";
 
       return (
-        <div class="flex flex-row w-[200px] py-2">
+        <div class="flex flex-row w-[200px] py-2 gap-x-2 mobile:max-xl:min-w-fit">
           <Icon name={iconName} class={`text-2xl ${iconStrokeColor}`} />
           <p
-            class={`ml-2 font-default text-sm font-semibold leading-6 text-left ${labelColor}`}
+            class={`font-default text-sm font-semibold leading-6 text-left ${labelColor}`}
           >
             {label}
           </p>

--- a/src/layouts/Navbar.astro
+++ b/src/layouts/Navbar.astro
@@ -3,7 +3,7 @@ import { Icon } from "astro-icon/components";
 import appLogo from "icons/logo.svg?raw";
 ---
 
-<div class="flex justify-between items-center my-3 mx-6">
+<div class="flex justify-between items-center my-3 mx-6 mobile:max-md:mx-4">
   <div class="flex flex-row items-center">
     <Fragment set:html={appLogo} />
     <p class="font-default font-semibold text-base ml-6">

--- a/src/pages/_DataMapping.svelte
+++ b/src/pages/_DataMapping.svelte
@@ -9,7 +9,7 @@
   setContext(CONTEXT_KEY_DATA_MAPPING_REPOSITORY, Repository());
 </script>
 
-<div class="flex flex-col gap-y-6">
+<div class="flex flex-col gap-y-6 mobile:max-md:gap-y-4">
   <DataOperationBar />
   <Tabs />
 </div>

--- a/src/styles/data_mapping_bar.css
+++ b/src/styles/data_mapping_bar.css
@@ -1,0 +1,13 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+@layer components {
+  .icon-only-on-mobile > p {
+    @apply mobile:max-md:hidden;
+  }
+
+  .icon-only-on-mobile {
+    @apply mobile:max-md:py-3 mobile:max-md:w-10;
+  }
+}

--- a/src/styles/drawer.css
+++ b/src/styles/drawer.css
@@ -22,4 +22,23 @@
   .drawer-toggle:checked ~ .drawer-side > div {
     box-shadow: 0px 2px 20px 0px #0000000f, 0px 1px 2px 0px #0000000f;
   }
+
+  .drawer .drawer-toggle ~ .drawer-side > div:not(.drawer-overlay) {
+    @apply w-drawer-width h-full;
+  }
+
+  @media (min-width: 320px) {
+    @media not all and (min-width: 768px) {
+      .drawer .drawer-toggle:checked ~ .drawer-side > div:not(.drawer-overlay) {
+        @apply w-full rounded-t-xl;
+        transform: translate(0, 64px) !important;
+        height: calc(100% - 64px);
+      }
+
+      .drawer .drawer-toggle ~ .drawer-side > div:not(.drawer-overlay) {
+        @apply w-full;
+        transform: translate(0, 100%) !important;
+      }
+    }
+  }
 }

--- a/src/styles/drawer.css
+++ b/src/styles/drawer.css
@@ -8,7 +8,11 @@
   }
 
   .drawer {
-    @apply !auto-cols-max;
+    @apply !auto-cols-max max-w-fit;
+  }
+
+  .drawer.grow {
+    @apply !max-w-full;
   }
 
   .drawer-toggle:checked ~ .drawer-side > .drawer-overlay {

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -4,9 +4,15 @@
 @tailwind components;
 @tailwind utilities;
 
+@media (max-height: 804px) {
+  .main_section {
+    height: 100% !important;
+  }
+}
+
 .main_section {
-  height: calc(100vh - 64px);
-  background: #0000000a;
+  height: calc(100vh - 64px /* Navbar */ - 44px /* Footer */);
+  @apply bg-app-bg;
 }
 
 p,

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -4,7 +4,7 @@
 @tailwind components;
 @tailwind utilities;
 
-@media (max-height: 804px) {
+@media (max-height: 768px) or (min-width: 768px) {
   .main_section {
     height: 100% !important;
   }

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -4,7 +4,7 @@
 @tailwind components;
 @tailwind utilities;
 
-@media (max-height: 804px) {
+@media (max-height: 799px) {
   .main_section {
     @apply md:!h-full;
   }

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -4,9 +4,9 @@
 @tailwind components;
 @tailwind utilities;
 
-@media (max-height: 768px) or (min-width: 768px) {
+@media (max-height: 804px) {
   .main_section {
-    height: 100% !important;
+    @apply md:!h-full;
   }
 }
 

--- a/src/styles/table.css
+++ b/src/styles/table.css
@@ -4,7 +4,7 @@
 
 @layer components {
   .table :where(th) {
-    @apply pb-3 pt-0 px-0;
+    @apply pb-3 pt-0 px-0 mobile:max-md:pb-2;
   }
 
   .table :where(th:not(:first-child)) {
@@ -16,7 +16,7 @@
   }
 
   .table :where(td) {
-    @apply px-0 pb-8 pt-3 min-w-52;
+    @apply px-0 pb-[30px] pt-3 min-w-52 text-nowrap mobile:max-md:min-w-35 mobile:max-md:pt-2 mobile:max-md:pb-[26px] mobile:max-md:h-5;
   }
 
   .table :where(td:not(:first-child)) {

--- a/src/styles/tabs.css
+++ b/src/styles/tabs.css
@@ -17,7 +17,7 @@
   }
 
   .tabs-bordered > .tab-content {
-    @apply !border-x-0 border-t border-t-app-border-default;
+    @apply !border-x-0 border-t border-t-app-border-default overflow-x-scroll;
   }
 
   .tabs-bordered > .tab {

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -7,6 +7,7 @@ export default {
         default: ["Inter", "san-serif"],
       },
       colors: {
+        "app-bg": "#0000000a",
         "app-green": "#009540",
         "app-black": "#000000D9",
         "app-bg-text": "#00000040",

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -25,6 +25,9 @@ export default {
       boxShadow: {
         textbox: "0px 1px 1px 0px #0000000A",
       },
+      screens: {
+        mobile: "320px",
+      },
     },
   },
   plugins: [require("daisyui")],

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -22,6 +22,7 @@ export default {
       spacing: {
         "drawer-width": "340px",
         19: "76px",
+        35: "140px",
       },
       boxShadow: {
         textbox: "0px 1px 1px 0px #0000000A",


### PR DESCRIPTION
- Add a responsive class that corresponds to mobile and tablet devices
- Add a special CSS for the button to show only the icon when displayed on mobile.
- Fix the footer overlapped with the main section by using relative display and dynamically calculate the height of the main section using CSS.
- Add a special CSS `transform`, `width`, `height` property that will allow drawers to slide from the bottom when displayed on mobile.